### PR TITLE
Add new ability to track generic goal triggers using TrackGoalTriggeredEvent

### DIFF
--- a/BotBuilder.Instrumentation.Benchmarks/BotFrameworkApplicationInsightsInstrumentationBenchmarks.cs
+++ b/BotBuilder.Instrumentation.Benchmarks/BotFrameworkApplicationInsightsInstrumentationBenchmarks.cs
@@ -154,6 +154,12 @@ namespace BotBuilder.Instrumentation.Benchmarks
             _defaultInstrumentation.TrackCustomEvent(_activity, customEventProperties: _customProperties);
         }
 
+        [Benchmark]
+        public void TrackGoalTriggeredEvent()
+        {
+            _defaultInstrumentation.TrackGoalTriggeredEvent(_activity, "Goal name");
+        }
+
         #endregion
     }
 }

--- a/Readme.md
+++ b/Readme.md
@@ -90,6 +90,11 @@ DefaultInstrumentation.TrackQnaEvent(activity, userQuery, kbQuestion, kbAnswer, 
 ```
 You can see how to implement a QnA service [here](https://github.com/Microsoft/BotBuilder-CognitiveServices/tree/master/CSharp/Samples/QnAMaker/QnABotWithOverrides)
 
+## Tracking generic Goals
+You can trigger generic goals, much like the way a Goal can be triggered on a web site in Google Analytics
+```
+DefaultInstrumentation.TrackGoalTriggeredEvent(activity, goalName, goalTriggeredEventProperties);
+```
 
 ## Tracking custom events
 You can send your own custom properties as `Dictionary<string, string>` to the telemetry.

--- a/botbuilder-instumentation/Instumentation/BotFrameworkInstrumentation.cs
+++ b/botbuilder-instumentation/Instumentation/BotFrameworkInstrumentation.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Threading.Tasks;
@@ -129,6 +130,19 @@ namespace BotBuilder.Instrumentation
                 et.Name = TelemetryEventTypes.MessageSentiment;
                 _telemetryClients.ForEach(c => c.TrackEvent(et));
             }
+        }
+
+        public void TrackGoalTriggeredEvent(IActivity activity, string goalName,
+            IDictionary<string, string> goalTriggeredEventProperties = null, string eventName = TelemetryEventTypes.GoalTriggeredEvent)
+        {
+            if(goalTriggeredEventProperties == null)
+                goalTriggeredEventProperties = new ConcurrentDictionary<string, string>();
+
+            goalTriggeredEventProperties.Add("GoalName", goalName);
+
+            var eventTelemetry = BuildEventTelemetry(activity, goalTriggeredEventProperties);
+            eventTelemetry.Name = string.IsNullOrWhiteSpace(eventName) ? TelemetryEventTypes.GoalTriggeredEvent : eventName;
+            _telemetryClients.ForEach(c => c.TrackEvent(eventTelemetry));
         }
 
         /// <summary>

--- a/botbuilder-instumentation/Interfaces/IBotFrameworkInstrumentation.cs
+++ b/botbuilder-instumentation/Interfaces/IBotFrameworkInstrumentation.cs
@@ -13,5 +13,6 @@ namespace BotBuilder.Instrumentation.Interfaces
         void TrackLuisIntent(IActivity activity, LuisResult result);
         void TrackQnaEvent(IActivity activity, string userQuery, string kbQuestion, string kbAnswer, double score);
         void TrackCustomEvent(IActivity activity, string eventName = Telemetry.TelemetryEventTypes.CustomEvent, IDictionary<string, string> customEventProperties = null);
+        void TrackGoalTriggeredEvent(IActivity activity, string goalName, IDictionary<string, string> goalTriggeredEventProperties = null, string eventName = Telemetry.TelemetryEventTypes.GoalTriggeredEvent);
     }
 }

--- a/botbuilder-instumentation/Telemetry/TelemetryEventTypes.cs
+++ b/botbuilder-instumentation/Telemetry/TelemetryEventTypes.cs
@@ -18,5 +18,6 @@ namespace BotBuilder.Instrumentation.Telemetry
         public const string ConversationEnded = "MBFEvent.EndConversation";
         public const string QnaEvent = "MBFEvent.QNAEvent";
         public const string CustomEvent = "MBFEvent.CustomEvent";
+        public const string GoalTriggeredEvent = "MBFEvent.GoalEvent";
     }
 }


### PR DESCRIPTION
This is to support a new preconfigured dashboard for tracking generic goals, similar to goals in Google Analytics https://github.com/CatalystCode/ibex-dashboard/pull/286 